### PR TITLE
Add support for auto-creation of successfully authenticated users

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The default login page will still work when you access it directly (http://examp
 The sessions have to be stored in the database to make Single Sign Out work.
 You can achieve this with a tiny plugin: [redmine_activerecord_session_store](https://github.com/pencil/redmine_activerecord_session_store)
 
+### Auto-create users
+
+By enabling this setting, successfully authenticated users will be automatically added into Redmine if they do not already exist. You *must* define the attribute mapping for at least firstname, lastname and mail attributes for this to work.
+
 ## Copyright
 
 Copyright (c) 2013 Nine Internet Solutions AG. See LICENSE.txt for further details.

--- a/app/views/redmine_cas/_settings.html.erb
+++ b/app/views/redmine_cas/_settings.html.erb
@@ -12,3 +12,8 @@
 	<%= text_field_tag "settings[attributes_mapping]", @settings[:attributes_mapping], :size => 50 %>
 	<em class="info"><%= l(:redmine_cas_settings_attributes_mapping_helptext, :attribute_names => User.attribute_names.join(', ')).html_safe %></em>
 </p>
+<p>
+	<%= label_tag "settings[autocreate_users]", l(:redmine_cas_settings_autocreate_users_label) %>
+	<%= check_box_tag "settings[autocreate_users]", 1, @settings[:autocreate_users] %>
+  <em class="info"><%= l(:redmine_cas_settings_autocreate_users_helptext).html_safe %></em>
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,4 +4,7 @@ en:
   redmine_cas_settings_cas_url_helptext: 'Base URL to your CAS server.'
   redmine_cas_settings_attributes_mapping_label: 'Attributes mapping'
   redmine_cas_settings_attributes_mapping_helptext: 'This is how the plugin maps extended attributes from the CAS server to the redmine model.<br /><code>attribute_name_in_redmine=attribute_name_in_cas_response</code><br />Separate entries with <code>&amp;</code> (query-string).<br />Example: <code>firstname=first_name&amp;lastname=last_name&amp;mail=email</code><br />Valid attribute names: <code>%{attribute_names}</code>'
+  redmine_cas_settings_autocreate_users_label: 'Auto-create users'
+  redmine_cas_settings_autocreate_users_helptext: 'Automatically create a redmine user if it is successfully authenticated.<br />Will only work if you specify firstname, lastname and mail in the attributes mapping setting above.'
   rbcas_cas_user_not_found: '"%{user}" was authenticated but needs to be created in Redmine first.'
+  rbcas_cas_user_not_created: '"%{user}" was authenticated but could not be created automatically in Redmine. It must be added manually.'

--- a/init.rb
+++ b/init.rb
@@ -7,14 +7,15 @@ Redmine::Plugin.register :redmine_cas do
   name 'Redmine CAS'
   author 'Nils Caspar (Nine Internet Solutions AG)'
   description 'Plugin to CASify your Redmine installation.'
-  version '1.0.1'
+  version '1.0.2'
   url 'https://github.com/ninech/redmine_cas'
   author_url 'http://www.nine.ch/'
 
   settings :default => {
     'enabled' => false,
     'cas_url' => 'https://',
-    'attributes_mapping' => 'firstname=first_name&lastname=last_name&mail=email'
+    'attributes_mapping' => 'firstname=first_name&lastname=last_name&mail=email',
+    'autocreate_users' => false
   }, :partial => 'redmine_cas/settings'
 
   Rails.configuration.to_prepare do

--- a/lib/redmine_cas.rb
+++ b/lib/redmine_cas.rb
@@ -12,6 +12,10 @@ module RedmineCAS
     setting(:enabled)
   end
 
+  def autocreate_users?
+    setting(:autocreate_users)
+  end
+
   def setup!
     return unless enabled?
     CASClient::Frameworks::Rails::Filter.configure(

--- a/lib/redmine_cas/application_controller_patch.rb
+++ b/lib/redmine_cas/application_controller_patch.rb
@@ -28,6 +28,16 @@ module RedmineCAS
       def login_with_cas
         if CASClient::Frameworks::Rails::Filter.filter(self)
           user = User.find_by_login(session[:cas_user])
+
+          # Auto-create user if possible
+          if user.nil? and RedmineCAS.autocreate_users?
+            user = User.new
+            user.login = session[:cas_user]
+            user.assign_attributes(RedmineCAS.user_extra_attributes_from_session(session))
+            return cas_user_not_created if !user.save
+            user.reload
+          end
+
           return cas_user_not_found if user.nil?
           return cas_account_pending unless user.active?
           user.update_attributes(RedmineCAS.user_extra_attributes_from_session(session))
@@ -50,6 +60,10 @@ module RedmineCAS
 
       def cas_user_not_found
         render_403 :message => l(:rbcas_cas_user_not_found, :user => session[:cas_user])
+      end
+
+      def cas_user_not_created
+        render_403 :message => l(:rbcas_cas_user_not_created, :user => session[:cas_user])
       end
     end
   end


### PR DESCRIPTION
I have added basic support for auto-creation of users into Redmine, to ease administrative maintenance of users with external SSO authentication.
There is a lot of potential for extensions, like email notification to admins, default role, and so on, but at least the users are easily and efficiently created.
