### PR TITLE
CAS authenticate after session expires

### DIFF
--- a/app/views/redmine_cas/_settings.html.erb
+++ b/app/views/redmine_cas/_settings.html.erb
@@ -17,3 +17,8 @@
   <%= check_box_tag "settings[autocreate_users]", 1, @settings[:autocreate_users] %>
   <em class="info"><%= l(:redmine_cas_settings_autocreate_users_helptext).html_safe %></em>
 </p>
+<p>
+  <%= label_tag "settings[cas_session_expiry]", l(:redmine_cas_settings_cas_session_expiry_label) %>
+  <%= check_box_tag "settings[cas_session_expiry]", 1, @settings[:cas_session_expiry] %>
+  <em class="info"><%= l(:redmine_cas_settings_cas_session_expiry_helptext).html_safe %></em>
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,5 +6,7 @@ en:
   redmine_cas_settings_attributes_mapping_helptext: 'This is how the plugin maps extended attributes from the CAS server to the Redmine model.<br /><code>attribute_name_in_redmine=attribute_name_in_cas_response</code><br />Separate entries with <code>&amp;</code> (query-string).<br />Example: <code>firstname=first_name&amp;lastname=last_name&amp;mail=email</code><br />Valid attribute names: <code>%{attribute_names}</code>'
   redmine_cas_settings_autocreate_users_label: 'Auto-create users'
   redmine_cas_settings_autocreate_users_helptext: 'Automatically create a redmine user if it is successfully authenticated.<br />Will only work if you specify firstname, lastname and mail in the attributes mapping setting above.'
+  redmine_cas_settings_cas_session_expiry_label: 'CAS authenticate after session expires'
+  redmine_cas_settings_cas_session_expiry_helptext: 'Automatically reauthenticate with CAS after the login session expires.'
   redmine_cas_user_not_found: '"%{user}" was authenticated but needs to be created in Redmine first.'
   redmine_cas_user_not_created: '"%{user}" was authenticated but could not be created automatically in Redmine. It must be added manually.'

--- a/init.rb
+++ b/init.rb
@@ -15,7 +15,8 @@ Redmine::Plugin.register :redmine_cas do
     'enabled' => false,
     'cas_url' => 'https://',
     'attributes_mapping' => 'firstname=first_name&lastname=last_name&mail=email',
-    'autocreate_users' => false
+    'autocreate_users' => false,
+    'cas_esssion_expiry' => false
   }, :partial => 'redmine_cas/settings'
 
   Rails.configuration.to_prepare do

--- a/lib/redmine_cas.rb
+++ b/lib/redmine_cas.rb
@@ -16,6 +16,10 @@ module RedmineCAS
     setting(:autocreate_users)
   end
 
+  def cas_session_expiry?
+	setting(:cas_session_expiry)
+  end
+
   def setup!
     return unless enabled?
     CASClient::Frameworks::Rails::Filter.configure(


### PR DESCRIPTION
Adds a **CAS authenticate after session expires** option to plugin settings.  When checked, the next request will authenticate with CAS instead of redirecting to the non-CAS login page.  When unchecked (the default), it retains the prior behavior.  See issue #7.

It works by overriding the `session_expiration` filter in `ApplicationController`.  When it detects an expired session, it resets the session and falls through.  The subsequent login check will trigger CAS authentication.

I haven't added a French translation for the new setting in `fr.yml`.
