### PR TITLE
This prevents an infinite redirect.

### DIFF
--- a/app/views/redmine_cas/_cas_login_link.html.erb
+++ b/app/views/redmine_cas/_cas_login_link.html.erb
@@ -1,5 +1,5 @@
 <% if Setting.plugin_redmine_cas[:enabled] %>
   <p style="text-align:center;">
-  <strong><%= link_to("Login with CAS", :controller => "account", :action => "cas") %></strong>
+  <strong><%= link_to("Login with CAS", :controller => "account", :action => "cas", :ref => '/my/page') %></strong>
   </p>
 <% end %>


### PR DESCRIPTION
When you are on a public page, and you click 'sign in',
and then 'sign in with CAS', you end up in an endless
redirect after entering your credentials. This patch fixes
the issue.